### PR TITLE
* when downloading a podcast, the http agent will now follow up to 10…

### DIFF
--- a/src/downloads.rs
+++ b/src/downloads.rs
@@ -60,7 +60,9 @@ pub fn download_list(
 fn download_file(mut ep_data: EpData, dest: PathBuf, mut max_retries: usize) -> DownloadMsg {
     let agent_builder = ureq::builder()
         .timeout_connect(Duration::from_secs(10))
-        .timeout_read(Duration::from_secs(120));
+        .timeout_read(Duration::from_secs(120))
+        .redirects(10);
+
     #[cfg(feature = "native_tls")]
     let tls_connector = std::sync::Arc::new(native_tls::TlsConnector::new().unwrap());
     #[cfg(feature = "native_tls")]

--- a/src/types.rs
+++ b/src/types.rs
@@ -416,7 +416,8 @@ impl<T: Clone + Menuable> LockVec<T> {
     /// *not* the sense of the word here.
     pub fn filter_map<B, F>(&self, mut f: F) -> Vec<B>
     where F: FnMut(&T) -> Option<B> {
-        let (map, order, _) = self.borrow();
+        let (map, order, _unused) = self.borrow();
+        drop(_unused);
         return order
             .iter()
             .filter_map(|id| f(map.get(id).expect("Index error in LockVec")))

--- a/src/ui/menu.rs
+++ b/src/ui/menu.rs
@@ -68,7 +68,8 @@ impl<T: Clone + Menuable> Menu<T> {
             self.selected = self.start_row;
         }
 
-        let (map, _, order) = self.items.borrow();
+        let (map, _unused, order) = self.items.borrow();
+        drop(_unused);
         if !order.is_empty() {
             // update selected item if list has gotten shorter
             let current_selected = self.get_menu_idx(self.selected);
@@ -284,7 +285,8 @@ impl Menu<Podcast> {
     /// currently selected podcast.
     pub fn get_episodes(&self) -> LockVec<Episode> {
         let index = self.get_menu_idx(self.selected);
-        let (borrowed_map, _, borrowed_order) = self.items.borrow();
+        let (borrowed_map, _unused, borrowed_order) = self.items.borrow();
+        drop(_unused);
         let pod_id = borrowed_order
             .get(index)
             .expect("Could not retrieve podcast.");
@@ -353,7 +355,8 @@ impl Menu<NewEpisode> {
     fn change_item_selections(&mut self, indexes: Vec<usize>, selection: Option<bool>) -> bool {
         let mut changed = false;
         {
-            let (mut borrowed_map, borrowed_order, _) = self.items.borrow();
+            let (mut borrowed_map, borrowed_order, _unused) = self.items.borrow();
+            drop(_unused);
             for idx in indexes {
                 if let Some(ep_id) = borrowed_order.get(idx) {
                     if let Entry::Occupied(mut ep) = borrowed_map.entry(*ep_id) {


### PR DESCRIPTION
… redirects \n* fixed a few instances of error: non-binding let on a synchronization lock

fixes https://github.com/jeff-hughes/shellcaster/issues/62